### PR TITLE
Fixes for Raspberry Os Bookworm: Refactor gpio-buttons.py for debounce and clarity / re-enable I2C to active display

### DIFF
--- a/scripts/gpio-buttons/gpio-buttons.py
+++ b/scripts/gpio-buttons/gpio-buttons.py
@@ -1,99 +1,118 @@
-#!/usr/bin/python3
-from gpiozero import Button
-from signal import pause
-from subprocess import check_call
+#!/usr/bin/env python3
+"""
+GPIO buttons for OLED Phoniebox — Bookworm-safe version.
+
+This file does NOT force a gpiozero pin factory (no RPiGPIOFactory forcing).
+It adds a software debounce wrapper for when_pressed handlers so the rapid
+spurious edges produced by some backends are filtered out while keeping
+when_held behavior intact.
+"""
+
+import time
 from time import sleep
+from subprocess import check_call
+from signal import pause
 
-# This script will block any I2S DAC e.g. from Hifiberry, Justboom, ES9023, PCM5102A
-# due to the assignment of GPIO 19 and 21 to a buttons
+from gpiozero import Button
 
-# 2018-10-31
-# Added the function on holding volume + - buttons to change the volume in 0.3s interval
-#
-# 2018-10-15
-# this script has the `pull_up=True` for all pins. See the following link for additional info:
-# https://github.com/MiczFlor/RPi-Jukebox-RFID/issues/259#issuecomment-430007446
-#
-# 2017-12-12
-# This script was copied from the following RPi forum post:
-# https://forum-raspberrypi.de/forum/thread/13144-projekt-jukebox4kids-jukebox-fuer-kinder/?postID=312257#post312257
-# I have not yet had the time to test is, so I placed it in the misc folder.
-# If anybody has ideas or tests or experience regarding this solution, please create pull requests or contact me.
-
+# Path to phoniebox/jukebox scripts (adjust if different in your install)
 jukebox4kidsPath = "/home/pi/RPi-Jukebox-RFID"
 
-def def_shutdown():
-    check_call(jukebox4kidsPath+"/scripts/playout_controls.sh -c=shutdown", shell=True)
-
+# --- action functions ------------------------------------------------------
 def def_volU():
-    check_call(jukebox4kidsPath+"/scripts/playout_controls.sh -c=volumeup", shell=True)
+    check_call(jukebox4kidsPath + "/scripts/playout_controls.sh -c=volumeup", shell=True)
 
 def def_volD():
-    check_call(jukebox4kidsPath+"/scripts/playout_controls.sh -c=volumedown", shell=True)
+    check_call(jukebox4kidsPath + "/scripts/playout_controls.sh -c=volumedown", shell=True)
 
 def def_vol0():
-    check_call(jukebox4kidsPath+"/scripts/playout_controls.sh -c=mute", shell=True)
+    check_call(jukebox4kidsPath + "/scripts/playout_controls.sh -c=mute", shell=True)
 
 def def_next():
     for x in range(0, 19):
-        if btn_next.is_pressed == True :
+        if btn_next.is_pressed:
             sleep(0.1)
         else:
-            check_call(jukebox4kidsPath+"/scripts/playout_controls.sh -c=playernext", shell=True)
+            check_call(jukebox4kidsPath + "/scripts/playout_controls.sh -c=playernext", shell=True)
             break
 
 def def_contrastup():
-    if btn_prev.is_pressed == True :
+    if btn_prev.is_pressed:
         check_call("/usr/bin/touch /tmp/o4p_overview.temp", shell=True)
     else:
         check_call("/usr/bin/python3 /home/pi/oled_phoniebox/scripts/contrast/contrast_up.py", shell=True)
 
 def def_contrastdown():
-    if btn_next.is_pressed == True :
+    if btn_next.is_pressed:
         check_call("/usr/bin/touch /tmp/o4p_overview.temp", shell=True)
     else:
         check_call("/usr/bin/python3 /home/pi/oled_phoniebox/scripts/contrast/contrast_down.py", shell=True)
 
 def def_prev():
     for x in range(0, 19):
-        if btn_prev.is_pressed == True :
+        if btn_prev.is_pressed:
             sleep(0.1)
         else:
-            check_call(jukebox4kidsPath+"/scripts/playout_controls.sh -c=playerprev", shell=True)
+            check_call(jukebox4kidsPath + "/scripts/playout_controls.sh -c=playerprev", shell=True)
             break
 
 def def_halt():
     for x in range(0, 19):
-        if btn_halt.is_pressed == True :
+        if btn_halt.is_pressed:
             sleep(0.1)
         else:
-            check_call(jukebox4kidsPath+"/scripts/playout_controls.sh -c=playerpause", shell=True)
+            check_call(jukebox4kidsPath + "/scripts/playout_controls.sh -c=playerpause", shell=True)
             break
-	
+
 def toggle_display():
     check_call("/home/pi/oled_phoniebox/scripts/toggle_display/toggle_display.sh", shell=True)
 
-#btn_shut = Button(3, hold_time=2)
-#btn_vol0 = Button(21,pull_up=True)
-btn_volup = Button(7,pull_up=True,hold_time=0.3,hold_repeat=True)
-btn_voldown = Button(13,pull_up=True,hold_time=0.3,hold_repeat=True)
-btn_next = Button(8,pull_up=True,hold_time=2.0,hold_repeat=False)
-btn_prev = Button(27,pull_up=True,hold_time=2.0,hold_repeat=False)
-btn_halt = Button(12,pull_up=True,hold_time=2.0,hold_repeat=False)
+# --- software debounce wrapper --------------------------------------------
+# We use a timestamp filter keyed by pin number so the first event runs
+# and further events within DEBOUNCE_MS are ignored. This is backend-agnostic.
+_last_event = {}
+DEBOUNCE_MS = 120  # milliseconds: tune between 60..200 depending on your tests
 
-#btn_shut.when_held = def_shutdown
-#btn_vol0.when_pressed = def_vol0
-btn_volup.when_pressed = def_volU
-#When the Volume Up button was held for more than 0.3 seconds every 0.3 seconds he will call a ra$
+def debounce_by_pin(pin_number, fn, debounce_ms=DEBOUNCE_MS):
+    def wrapped(*a, **k):
+        now = int(time.time() * 1000)
+        last = _last_event.get(pin_number, 0)
+        if now - last < debounce_ms:
+            # ignore as bounce/duplicate
+            return
+        _last_event[pin_number] = now
+        try:
+            return fn(*a, **k)
+        except Exception:
+            # prevent exception from killing the service; let it be visible in journal
+            import traceback
+            traceback.print_exc()
+    return wrapped
+
+# --- Buttons configuration -----------------------------------------------
+# Keep pull_up and hold_time/hold_repeat behaviour from original script.
+# We do NOT force a pin factory here (so it will use the distro/default one).
+# You can increase bounce_time if desired, but the debounce wrapper will be the main defense.
+btn_volup = Button(7, pull_up=True, hold_time=0.3, hold_repeat=True, bounce_time=0.01)
+btn_voldown = Button(13, pull_up=True, hold_time=0.3, hold_repeat=True, bounce_time=0.01)
+btn_next = Button(8, pull_up=True, hold_time=2.0, hold_repeat=False, bounce_time=0.01)
+btn_prev = Button(27, pull_up=True, hold_time=2.0, hold_repeat=False, bounce_time=0.01)
+btn_halt = Button(12, pull_up=True, hold_time=2.0, hold_repeat=False, bounce_time=0.01)
+
+# Attach handlers: wrap only the when_pressed handlers (keep when_held direct)
+btn_volup.when_pressed = debounce_by_pin(7, def_volU)
 btn_volup.when_held = def_volU
-btn_voldown.when_pressed = def_volD
-#When the Volume Down button was held for more than 0.3 seconds every 0.3 seconds he will lower t$
+
+btn_voldown.when_pressed = debounce_by_pin(13, def_volD)
 btn_voldown.when_held = def_volD
-btn_next.when_pressed = def_next
+
+btn_next.when_pressed = debounce_by_pin(8, def_next)
 btn_next.when_held = def_contrastup
-btn_prev.when_pressed = def_prev
+
+btn_prev.when_pressed = debounce_by_pin(27, def_prev)
 btn_prev.when_held = def_contrastdown
-btn_halt.when_pressed = def_halt
+
+btn_halt.when_pressed = debounce_by_pin(12, def_halt)
 btn_halt.when_held = toggle_display
 
 pause()

--- a/scripts/install/o4p_installer.sh
+++ b/scripts/install/o4p_installer.sh
@@ -313,6 +313,8 @@ else
   echo -e "   --> i2c arm_baudrate:        ${green}set${nocolor}"
 fi
 
+# Ensure the I2C interface is enabled via raspi-config (fixes disabled display on some Bookworm installs)
+sudo raspi-config nonint do_i2c 0 > /dev/null 2>&1
 
 if [ -f /etc/modprobe.d/raspi-blacklist.conf ]; then
   sudo sed -i 's/^blacklist spi-bcm2708/#blacklist spi-bcm2708/' /etc/modprobe.d/raspi-blacklist.conf


### PR DESCRIPTION
Updated GPIO button script for OLED Phoniebox to include software debounce and improved button handling. Also re-enabling I2C (display disabled if not active). Code changes suggested by copilot, tested by me.

Root cause: Bookworm’s default gpio backend produces very-rapid spurious edges for your hardware that were interpreted as many presses; Bullseye used a different backend and did not show this behavior.
Fix applied to gpio-buttons.py (on-device): added a backend-agnostic software debounce wrapper for when_pressed handlers plus a small bounce_time — this prevents the sub-millisecond PRESSED/RELEASED bursts from firing multiple actions while leaving when_held behavior intact. After that change the service starts normally and the duplicate-presses are gone on Bookworm device.
Display works as usual after I2C is reenabled.
